### PR TITLE
Fix build with g++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ tokens.cpp: tokens.l parser.hpp
 
 
 parser: $(OBJS)
-	g++ -o $@ $(LDFLAGS) $(OBJS) $(LIBS)
+	g++ -o $@ $(OBJS) $(LIBS) $(LDFLAGS)
 
 


### PR DESCRIPTION
Makefile was using the following recipe for parser:

```
g++ -o $@  $(LDFLAGS) $(OBJS) $(LIBS)
```

`LDFLAGS` contains linker flags such as `-ldl` and `-lpthread`. But g++ requires that linker flags come after the object files that require functions from the linked libraries. Because `LDFLAGS` came before `OBJS` and `LIBS`, g++ fails with linker errors (at least on my Ubuntu 12.04 box).

The fix is simple: Move `LDFLAGS` to the end:

```
g++ -o $@  $(OBJS) $(LIBS) $(LDFLAGS) 
```

This patch does that.
