### PR TITLE
support clang 3.5.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 all: parser
 
 OBJS = parser.o  \
+       corefn.o  \
        codegen.o \
        main.o    \
        tokens.o  \
-       corefn.o  \
 
 CPPFLAGS = `llvm-config --cppflags`
 LDFLAGS = `llvm-config --ldflags`
-LIBS = `llvm-config --libs`
+LIBS = `llvm-config --libs` -lz -ldl -pthread -lcurses
 
 clean:
 	$(RM) -rf parser.cpp parser.hpp parser tokens.cpp $(OBJS)
@@ -22,10 +22,10 @@ tokens.cpp: tokens.l parser.hpp
 	flex -o $@ $^
 
 %.o: %.cpp
-	g++ -c $(CPPFLAGS) -o $@ $<
+	clang++ -std=c++11 -c $(CPPFLAGS) -o $@ $<
 
 
 parser: $(OBJS)
-	g++ -o $@ $(OBJS) $(LIBS) $(LDFLAGS)
+	clang++  -std=c++11 -o $@ $(OBJS) $(LIBS) $(LDFLAGS)
 
 

--- a/codegen.cpp
+++ b/codegen.cpp
@@ -26,7 +26,7 @@ void CodeGenContext::generateCode(NBlock& root)
 	 */
 	std::cout << "Code is generated.\n";
 	PassManager pm;
-	pm.add(createPrintModulePass(&outs()));
+	pm.add(createPrintModulePass(outs()));
 	pm.run(*module);
 }
 

--- a/codegen.h
+++ b/codegen.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <stack>
 #include <typeinfo>
 #include <llvm/IR/Module.h>
@@ -9,14 +10,14 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/CallingConv.h>
 #include <llvm/Bitcode/ReaderWriter.h>
-#include <llvm/Analysis/Verifier.h>
-#include <llvm/Assembly/PrintModulePass.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/IR/Constants.h>
 //#include <llvm/ModuleProvider.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/ExecutionEngine/GenericValue.h>
 #include <llvm/ExecutionEngine/JIT.h>
 #include <llvm/Support/raw_ostream.h>
-
+#include <llvm/LinkAllPasses.h>
 using namespace llvm;
 
 class NBlock;


### PR DESCRIPTION
This makes the code compile on clang 3.5.x, I'm surprised the code compiled at all on older versions without `-std=c++11`.

Should fix https://github.com/lsegal/my_toy_compiler/issues/17 and maybe https://github.com/lsegal/my_toy_compiler/issues/15 too.
