### PR TITLE
Clean main.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -12,7 +12,7 @@ void createCoreFunctions(CodeGenContext& context);
 int main(int argc, char **argv)
 {
 	yyparse();
-	std::cout << programBlock << endl;
+	cout << programBlock << endl;
     // see http://comments.gmane.org/gmane.comp.compilers.llvm.devel/33877
 	InitializeNativeTarget();
 	CodeGenContext context;


### PR DESCRIPTION
Removed an obsolete "std::" statement, because there's a "using namespace std;" in Line 5.
