### PR TITLE
LLVM 3.7 compatibility.

### DIFF
--- a/codegen.cpp
+++ b/codegen.cpp
@@ -25,15 +25,16 @@ void CodeGenContext::generateCode(NBlock& root)
 	   to see if our program compiled properly
 	 */
 	std::cout << "Code is generated.\n";
-	PassManager pm;
-	pm.add(createPrintModulePass(outs()));
+	PassManager<Module> pm;
+	pm.addPass(PrintModulePass(outs()));
 	pm.run(*module);
 }
 
 /* Executes the AST by running the main function */
 GenericValue CodeGenContext::runCode() {
 	std::cout << "Running code...\n";
-	ExecutionEngine *ee = EngineBuilder(module).create();
+	ExecutionEngine *ee = EngineBuilder( unique_ptr<Module>(module) ).create();
+	ee->finalizeObject();
 	vector<GenericValue> noargs;
 	GenericValue v = ee->runFunction(mainFunction, noargs);
 	std::cout << "Code was run.\n";

--- a/codegen.h
+++ b/codegen.h
@@ -5,15 +5,16 @@
 #include <llvm/IR/Type.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/LLVMContext.h>
-#include <llvm/PassManager.h>
+#include <llvm/IR/PassManager.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/CallingConv.h>
 #include <llvm/IR/IRPrintingPasses.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/Bitcode/ReaderWriter.h>
 #include <llvm/Support/TargetSelect.h>
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+#include <llvm/ExecutionEngine/MCJIT.h>
 #include <llvm/ExecutionEngine/GenericValue.h>
-#include <llvm/ExecutionEngine/JIT.h>
 #include <llvm/Support/raw_ostream.h>
 
 using namespace llvm;

--- a/corefn.cpp
+++ b/corefn.cpp
@@ -55,8 +55,9 @@ void createEchoFunction(CodeGenContext& context, llvm::Function* printfFn)
     std::vector<llvm::Constant*> indices;
     indices.push_back(zero);
     indices.push_back(zero);
-    llvm::Constant *var_ref =
-        llvm::ConstantExpr::getGetElementPtr(var, indices);
+    llvm::Constant *var_ref = llvm::ConstantExpr::getGetElementPtr(
+	llvm::ArrayType::get(llvm::IntegerType::get(getGlobalContext(), 8), strlen(constValue+1)),
+        var, indices);
 
     std::vector<Value*> args;
     args.push_back(var_ref);

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,8 @@ int main(int argc, char **argv)
 	cout << programBlock << endl;
     // see http://comments.gmane.org/gmane.comp.compilers.llvm.devel/33877
 	InitializeNativeTarget();
+	InitializeNativeTargetAsmPrinter();
+	InitializeNativeTargetAsmParser();
 	CodeGenContext context;
 	createCoreFunctions(context);
 	context.generateCode(*programBlock);

--- a/node.h
+++ b/node.h
@@ -102,7 +102,7 @@ public:
 	NIdentifier& id;
 	NExpression *assignmentExpr;
 	NVariableDeclaration(const NIdentifier& type, NIdentifier& id) :
-		type(type), id(id) { }
+		type(type), id(id) { assignmentExpr = NULL; }
 	NVariableDeclaration(const NIdentifier& type, NIdentifier& id, NExpression *assignmentExpr) :
 		type(type), id(id), assignmentExpr(assignmentExpr) { }
 	virtual llvm::Value* codeGen(CodeGenContext& context);


### PR DESCRIPTION
@lsegal, I was reading through your gnuu.org article today and ran into trouble with LLVM version differences.

This patch should fix issue #28  -- and others involving changes to LLVM-- to some extent, but take that with the caveat that today was my first programming exposure to flex, bison, or LLVM, so this is the best I could put together from the docs on llvm.org. I'm not sure that what I've written is correct, but insofar as I can tell, it *does work* with the example program.

Below is the output of the example program.

```
0x1835f70                                                                         
Generating code...
Generating code for 18NExternDeclaration
Generating code for 20NFunctionDeclaration
Creating variable declaration int a
Generating code for 20NVariableDeclaration
Creating variable declaration int x
Creating assignment for x
Creating binary operation 276
Creating integer: 5
Creating identifier reference: a
Generating code for 16NReturnStatement
Generating return code for 15NBinaryOperator
Creating binary operation 274
Creating integer: 3
Creating identifier reference: x
Creating block
Creating function: do_math
Generating code for 20NExpressionStatement
Generating code for 11NMethodCall
Creating integer: 11
Creating method call: do_math
Creating method call: echo
Generating code for 20NExpressionStatement
Generating code for 11NMethodCall
Creating integer: 12
Creating method call: do_math
Creating method call: echo
Generating code for 20NExpressionStatement
Generating code for 11NMethodCall
Creating integer: 10
Creating method call: printi
Creating block
Code is generated.
; ModuleID = 'main'

@.str = private constant [4 x i8] c"%d\0A\00"

declare i32 @printf(i8*, ...)

define internal void @echo(i64 %toPrint) {
entry:
  %0 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i32 0, i32 0), i64 %toPrint)
  ret void
}

define internal void @main() {
entry:
  %0 = call i64 @do_math(i64 11)
  call void @echo(i64 %0)
  %1 = call i64 @do_math(i64 12)
  call void @echo(i64 %1)
  call void @printi(i64 10)
  ret void
}

declare void @printi(i64)

define internal i64 @do_math(i64 %a1) {
entry:
  %a = alloca i64
  store i64 %a1, i64* %a
  %x = alloca i64
  %0 = load i64, i64* %a
  %1 = mul i64 %0, 5
  store i64 %1, i64* %x
  %2 = load i64, i64* %x
  %3 = add i64 %2, 3
  ret i64 %3
}
Running code...
58
63
10
Code was run.
```

However, the program
```
double do_math( double d ) {
  double x = d / 2
  return x
}

do_math( 1.1 )
```
does not run, though I expected it to, and produces an error
```
; ModuleID = 'main'

@.str = private constant [4 x i8] c"%d\0A\00"

declare i32 @printf(i8*, ...)

define internal void @echo(i64 %toPrint) {
entry:
  %0 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i32 0, i32 0), i64 %toPrint)
  ret void
}

define internal void @main() {
entry:
  %0 = call double @do_math(double 1.100000e+00)
  ret void
}

define internal double @do_math(double %a1) {
entry:
  %a = alloca double
  store double %a1, double* %a
  %x = alloca double
  %0 = load double, double* %a
  %1 = sdiv double %0, i64 2
  store double %1, double* %x
  %2 = load double, double* %x
  ret double %2
}
Running code...

LLVM ERROR: Cannot select: 0x1aeb058: f64 = sra 0x1aea968, 0x1aecac8 [ORD=6] [ID=13]
  0x1aea968: f64 = add 0x1aec060, 0x1aec628 [ORD=6] [ID=12]
    0x1aec060: f64,ch = CopyFromReg 0x1a91610, 0x1aeb4f8 [ORD=1] [ID=9]
      0x1aeb4f8: f64 = Register %vreg0 [ID=1]
    0x1aec628: f64 = srl 0x1aec060, 0x1aeb3d0 [ORD=6] [ID=10]
      0x1aec060: f64,ch = CopyFromReg 0x1a91610, 0x1aeb4f8 [ORD=1] [ID=9]
        0x1aeb4f8: f64 = Register %vreg0 [ID=1]
      0x1aeb3d0: i8 = Constant<63> [ID=8]
  0x1aecac8: i8 = Constant<1> [ID=7]
In function: do_math
```

I'm not sure how anything I might have done to the code would produce a regression like this, if indeed it is a regression. Comments?

Tested on Arch Linux w/ `llvm 3.7.0-6`

Cheers,
Signed-off-by: William Temple <wmtemple@wpi.edu>