### PR TITLE
change main function's define

### DIFF
--- a/codegen.cpp
+++ b/codegen.cpp
@@ -12,7 +12,7 @@ void CodeGenContext::generateCode(NBlock& root)
 	/* Create the top level interpreter function to call as entry */
 	vector<Type*> argTypes;
 	FunctionType *ftype = FunctionType::get(Type::getVoidTy(MyContext), makeArrayRef(argTypes), false);
-	mainFunction = Function::Create(ftype, GlobalValue::InternalLinkage, "main", module);
+	mainFunction = Function::Create(ftype, GlobalValue::ExternalLinkage, "main", module);
 	BasicBlock *bblock = BasicBlock::Create(MyContext, "entry", mainFunction, 0);
 	
 	/* Push a new variable/block context */


### PR DESCRIPTION
Hi.
I want use “LLVM assembly code”(createPrintModulePass(outs())) to compile “llc” command.
So, "main function" need define “GlobalValue::ExternalLinkage” at codegen.cpp

—hope output(LLVM assembly code)—
define void @main() {
entry:
…etc
}

—current output(LLVM assembly code)— 
define internal void @main() {
entry:
…etc
}