### PR TITLE
Changed APIs calls

### DIFF
--- a/codegen.cpp
+++ b/codegen.cpp
@@ -76,7 +76,7 @@ Value* NIdentifier::codeGen(CodeGenContext& context)
 		std::cerr << "undeclared variable " << name << endl;
 		return NULL;
 	}
-	return new LoadInst(context.locals()[name], "", false, context.currentBlock());
+	return new LoadInst(context.locals()[name]->getType()->getPointerElementType(),context.locals()[name], "", false, context.currentBlock());
 }
 
 Value* NMethodCall::codeGen(CodeGenContext& context)
@@ -153,7 +153,7 @@ Value* NReturnStatement::codeGen(CodeGenContext& context)
 Value* NVariableDeclaration::codeGen(CodeGenContext& context)
 {
 	std::cout << "Creating variable declaration " << type.name << " " << id.name << endl;
-	AllocaInst *alloc = new AllocaInst(typeOf(type), id.name.c_str(), context.currentBlock());
+	AllocaInst *alloc = new AllocaInst(typeOf(type), NULL, id.name.c_str(), context.currentBlock());
 	context.locals()[id.name] = alloc;
 	if (assignmentExpr != NULL) {
 		NAssignment assn(id, *assignmentExpr);


### PR DESCRIPTION
Some APIs (lines 79 and 156) used in the project may have become deprecated because I can't find matching member functions to call anywhere on the current LLVM API reference documentation. I did some fixes that make the code work with LLVM 12. Feel free to give me a correction if I overlooked anything.