### PR TITLE
Add lzstd to target compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJS = parser.o  \
 
 LLVMCONFIG = llvm-config
 CPPFLAGS = `$(LLVMCONFIG) --cppflags` -std=c++14
-LDFLAGS = `$(LLVMCONFIG) --ldflags` -lpthread -ldl -lz -lncurses -rdynamic
+LDFLAGS = `$(LLVMCONFIG) --ldflags` -lpthread -ldl -lzstd -lz -lncurses -rdynamic
 LIBS = `$(LLVMCONFIG) --libs`
 
 clean:


### PR DESCRIPTION
Hey,

Thanks for the article.
I think some functions were moved to a different library and the compilation breaks without them.

```shell
make all
...
clang++  -gfull -o parser parser.o codegen.o main.o tokens.o corefn.o native.o  `llvm-config --libs` `llvm-config --ldflags` -lpthread -ldl -lz -lncurses -rdynamic
/bin/ld: /usr/lib/libLLVMSupport.a(Compression.cpp.o): in function `llvm::compression::zstd::compress(llvm::ArrayRef<unsigned char>, llvm::SmallVectorImpl<unsigned char>&, int)':
(.text._ZN4llvm11compression4zstd8compressENS_8ArrayRefIhEERNS_15SmallVectorImplIhEEi+0x1d): undefined reference to `ZSTD_compressBound'
/bin/ld: (.text._ZN4llvm11compression4zstd8compressENS_8ArrayRefIhEERNS_15SmallVectorImplIhEEi+0x47): undefined reference to `ZSTD_compress'
/bin/ld: (.text._ZN4llvm11compression4zstd8compressENS_8ArrayRefIhEERNS_15SmallVectorImplIhEEi+0x53): undefined reference to `ZSTD_isError'
/bin/ld: /usr/lib/libLLVMSupport.a(Compression.cpp.o): in function `llvm::compression::zstd::uncompress(llvm::ArrayRef<unsigned char>, unsigned char*, unsigned long&)':
(.text._ZN4llvm11compression4zstd10uncompressENS_8ArrayRefIhEEPhRm+0x32): undefined reference to `ZSTD_decompress'
/bin/ld: (.text._ZN4llvm11compression4zstd10uncompressENS_8ArrayRefIhEEPhRm+0x42): undefined reference to `ZSTD_isError'
/bin/ld: (.text._ZN4llvm11compression4zstd10uncompressENS_8ArrayRefIhEEPhRm+0x89): undefined reference to `ZSTD_getErrorName'
/bin/ld: /usr/lib/libLLVMSupport.a(Compression.cpp.o): in function `llvm::compression::zstd::uncompress(llvm::ArrayRef<unsigned char>, llvm::SmallVectorImpl<unsigned char>&, unsigned long)'
:
(.text._ZN4llvm11compression4zstd10uncompressENS_8ArrayRefIhEERNS_15SmallVectorImplIhEEm+0x59): undefined reference to `ZSTD_decompress'
/bin/ld: (.text._ZN4llvm11compression4zstd10uncompressENS_8ArrayRefIhEERNS_15SmallVectorImplIhEEm+0x65): undefined reference to `ZSTD_isError'
/bin/ld: (.text._ZN4llvm11compression4zstd10uncompressENS_8ArrayRefIhEERNS_15SmallVectorImplIhEEm+0xbb): undefined reference to `ZSTD_getErrorName'
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:31: parser] Error 1
```

I added the `-lzstd` flag which seems to have resolved the issue.